### PR TITLE
fix: Installer being missing on /tmp

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,7 +8,6 @@ RUN sudo apt-get update \
         default-jre \
         libxtst-dev
 
-# Install Eclipse
-RUN wget "http://eclipse.mirror.rafal.ca/oomph/epp/2019-12/R/eclipse-inst-linux64.tar.gz" \
-    && tar -xf *.tar.gz \
-    && mv eclipse-installer /tmp
+# Download Eclipse GUI installer
+RUN wget -c "http://eclipse.mirror.rafal.ca/oomph/epp/2019-12/R/eclipse-inst-linux64.tar.gz" \
+    -O - | tar -xpz -C $HOME

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 image:
-  file: Dockerfile
+  file: .gitpod.Dockerfile
 ports:
   - port: 6080
     onOpen: open-browser
@@ -8,4 +8,6 @@ ports:
   - port: 35900
     onOpen: ignore
 tasks:
-  - command: cd /tmp/eclipse-installer && ./eclipse-inst
+  - command: |
+      cd $HOME/eclipse-installer
+      chmod +x eclipse-inst && ./eclipse-inst


### PR DESCRIPTION
## Description
Previously the installer was downloaded to `/tmp` but it's no longer accessible now since `/tmp` is a `tmpfs` mountpoint. So I extract it under `$HOME`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open this PR in Gitpod.
- See the VNC tab.
- Interact with the installer.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

No change required.
